### PR TITLE
Fix namespace for ConfigAggregatorTest class

### DIFF
--- a/test/Container/Config/ConfigAggregatorTest.php
+++ b/test/Container/Config/ConfigAggregatorTest.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Antidot\SymfonyConfigTranslator\Container\Config;
+namespace AntidotTest\SymfonyConfigTranslator\Container\Config;
 
 use PHPUnit\Framework\TestCase;
+use Antidot\SymfonyConfigTranslator\Container\Config\ConfigAggregator;
 use Zend\ConfigAggregator\ArrayProvider;
 
 class ConfigAggregatorTest extends TestCase


### PR DESCRIPTION
# Changed log

- Fixing namespace to be `AntidotTest\SymfonyConfigTranslator\Container\Config` for `ConfigAggregatorTest` class.